### PR TITLE
Placeholder lspconfig for when the NPM package is shipped

### DIFF
--- a/packages/neovim/lspconfig/wc.lua
+++ b/packages/neovim/lspconfig/wc.lua
@@ -1,0 +1,41 @@
+---@type vim.lsp.Config
+return {
+  init_options = { hostInfo = 'neovim' },
+  cmd = { 'wc-language-server', '--stdio' },
+  filetypes = {
+      'javascript',
+      'javascriptreact',
+      'javascript.jsx',
+      'typescript',
+      'typescriptreact',
+      'typescript.tsx',
+      "html",
+      "handlebars",
+      "htmldjango",
+      "javascript",
+      "javascriptreact",
+      "typescript",
+      "typescriptreact",
+      "vue",
+      "svelte",
+      "astro",
+      "twig",
+      "css",
+      "scss",
+      "less",
+      "markdown",
+      "mdx",
+  },
+  root_dir = function(bufnr, on_dir)
+    local root_markers = { 'package-lock.json', 'yarn.lock', 'pnpm-lock.yaml', 'bun.lockb', 'bun.lock', 'tsconfig.json', 'jsconfig.json', 'wc.config.js' }
+    -- Give the root markers equal priority by wrapping them in a table
+    root_markers = vim.fn.has('nvim-0.11.3') == 1 and { root_markers, { '.git' } }
+      or vim.list_extend(root_markers, { '.git' })
+    -- We fallback to the current working directory if no project root is found
+    local project_root = vim.fs.root(bufnr, root_markers) or vim.fn.getcwd()
+
+    on_dir(project_root)
+  end,
+}
+
+


### PR DESCRIPTION
Heya!

I tried out the build from this branch, building it and installing it globally (to simulate installing via npm).

After that, I modified my `nvim-lspconfig` installation to attach to this lsp via the file provided in this PR.

When we get around to serving this package via NPM, this PR's files should be added via a PR to the [LSPConfig](https://github.com/neovim/nvim-lspconfig) project, as well as the [Mason Registry](https://github.com/mason-org/mason.nvim).

I'll be happy to help with those when we get the npm package set up.


---

Basically steps for enabling the LSP in it's current state on neovim:

1. Install nvim-lspconfig
2. Build the Language server
3. Install it globally via `npm install -g .`
4. Add the `wc.lua` file in your lspconfig at `nvim-lspconfig/lsp/wc.lua`
5. Enable the LSP via lspconfig `vim.lsp.enable("wc")`